### PR TITLE
feat: preserve exact SQL source slices and parser offsets

### DIFF
--- a/src/slowql/core/models.py
+++ b/src/slowql/core/models.py
@@ -435,6 +435,8 @@ class Query:
     normalized: str
     dialect: str
     location: Location
+    start_offset: int | None = None
+    end_offset: int | None = None
     ast: Any = None
     tables: tuple[str, ...] = field(default_factory=tuple)
     columns: tuple[str, ...] = field(default_factory=tuple)

--- a/src/slowql/parser/source_splitter.py
+++ b/src/slowql/parser/source_splitter.py
@@ -1,0 +1,170 @@
+# slowql/src/slowql/parser/source_splitter.py
+"""
+SQL statement splitter that preserves source anchoring information.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class StatementSlice:
+    """
+    A slice of an original SQL string corresponding to a single statement.
+
+    Attributes:
+        raw: The exact raw text of the statement.
+        start_offset: The character offset where the statement starts.
+        end_offset: The character offset where the statement ends (exclusive).
+        line: The 1-indexed line number where the statement starts.
+        column: The 1-indexed column number where the statement starts.
+    """
+
+    raw: str
+    start_offset: int
+    end_offset: int
+    line: int
+    column: int
+
+
+class SourceSplitter:
+    """
+    Splits a multi-statement SQL string into individual statements while
+    preserving exact source text and offsets.
+    """
+
+    def split(self, sql: str) -> list[StatementSlice]:  # noqa: PLR0912
+        """
+        Split a SQL string into individual statements.
+
+        Args:
+            sql: The SQL string to split.
+
+        Returns:
+            A list of StatementSlice objects.
+        """
+        if not sql:
+            return []
+
+        slices: list[StatementSlice] = []
+        i = 0
+        n = len(sql)
+
+        while i < n:
+            # 1. Skip leading whitespace and comments to find the true statement start
+            stmt_sql_start = self._find_first_token(sql, i, n)
+            if stmt_sql_start >= n:
+                break
+
+            # 2. Track where we are in the state machine to find the semicolon
+            j = stmt_sql_start
+            found_semicolon = False
+            while j < n:
+                char = sql[j]
+                if char == "'":
+                    j = self._skip_quoted(sql, j, n, "'")
+                elif char == '"':
+                    j = self._skip_quoted(sql, j, n, '"')
+                elif char == '`':
+                    j = self._skip_quoted(sql, j, n, '`')
+                elif char == '-' and j + 1 < n and sql[j + 1] == '-':
+                    j = self._skip_line_comment(sql, j, n)
+                elif char == '/' and j + 1 < n and sql[j + 1] == '*':
+                    j = self._skip_block_comment(sql, j, n)
+                elif char == ';':
+                    found_semicolon = True
+                    j += 1
+                    break
+                else:
+                    j += 1
+
+            # 3. We found a statement boundary (semicolon or EOF)
+            # The raw text is from stmt_sql_start to j, but we trim trailing whitespace (except the ;)
+            stmt_end = j
+            raw = sql[stmt_sql_start:stmt_end]
+
+            # If we didn't end on a semicolon, we might have trailing whitespace to trim
+            if not found_semicolon:
+                raw_trimmed = raw.rstrip()
+                stmt_end = stmt_sql_start + len(raw_trimmed)
+                raw = raw_trimmed
+            else:
+                # If we have a semicolon, it's at j-1. We should trim whitespace BETWEEN the last token and ; if needed?
+                # Actually, "exclude trailing whitespace after the statement terminator"
+                # If sql is "SELECT 1;  ", raw should be "SELECT 1;"
+                # Current j is after the semicolon. So raw is "SELECT 1;" (if it was "SELECT 1; ")
+                # Let's just rstrip the raw but ensure if last char was ;, we keep it.
+                # Simplified: raw is already mapped to j. If we found a semicolon, j is just after it.
+                # If there was a semicolon, we don't trim anything because the semicolon is the terminator.
+                # Wait, "SELECT 1 ;  " -> raw should be "SELECT 1 ;"
+                # My logic: stmt_sql_start="S", j=" " (after ;). raw="SELECT 1 ;". Correct.
+                pass
+
+            if raw:
+                # Calculate line/column for stmt_sql_start
+                line, column = self._get_location(sql, stmt_sql_start)
+                slices.append(StatementSlice(
+                    raw=raw,
+                    start_offset=stmt_sql_start,
+                    end_offset=stmt_end,
+                    line=line,
+                    column=column
+                ))
+
+            # Move i to j to continue searching for the next statement
+            i = j
+
+        return slices
+
+    def _find_first_token(self, sql: str, start: int, n: int) -> int:
+        """Find the index of the first character that is not whitespace or part of a comment."""
+        i = start
+        while i < n:
+            char = sql[i]
+            if char.isspace():
+                i += 1
+            elif char == '-' and i + 1 < n and sql[i + 1] == '-':
+                i = self._skip_line_comment(sql, i, n)
+            elif char == '/' and i + 1 < n and sql[i + 1] == '*':
+                i = self._skip_block_comment(sql, i, n)
+            else:
+                return i
+        return n
+
+    def _get_location(self, sql: str, offset: int) -> tuple[int, int]:
+        prefix = sql[:offset]
+        line = prefix.count('\n') + 1
+        last_newline = prefix.rfind('\n')
+        if last_newline == -1:
+            column = offset + 1
+        else:
+            column = offset - last_newline
+        return line, column
+
+    def _skip_quoted(self, sql: str, start: int, n: int, quote: str) -> int:
+        i = start + 1
+        while i < n:
+            if sql[i] == quote:
+                if i + 1 < n and sql[i + 1] == quote:
+                    i += 2
+                    continue
+                return i + 1
+            i += 1
+        return n
+
+    def _skip_line_comment(self, sql: str, start: int, n: int) -> int:
+        i = start + 2
+        while i < n:
+            if sql[i] == '\n':
+                return i + 1
+            i += 1
+        return n
+
+    def _skip_block_comment(self, sql: str, start: int, n: int) -> int:
+        i = start + 2
+        while i < n:
+            if sql[i] == '*' and i + 1 < n and sql[i + 1] == '/':
+                return i + 2
+            i += 1
+        return n

--- a/src/slowql/parser/universal.py
+++ b/src/slowql/parser/universal.py
@@ -18,6 +18,7 @@ from sqlglot.errors import ParseError as SqlglotParseError
 from slowql.core.exceptions import ParseError, UnsupportedDialectError
 from slowql.core.models import Location, Query
 from slowql.parser.base import BaseParser
+from slowql.parser.source_splitter import SourceSplitter
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -77,34 +78,42 @@ class UniversalParser(BaseParser):
         Raises:
             ParseError: If parsing fails.
         """
-        statements = self._split_statements(sql)
+        splitter = SourceSplitter()
+        try:
+            statements = splitter.split(sql)
+        except Exception as e:
+            raise ParseError(
+                "An unexpected error occurred during SQL splitting.", details=str(e)
+            ) from e
         queries = []
 
-        for i, (statement_sql, location) in enumerate(statements):
+        for i, stmt in enumerate(statements):
             try:
                 # Use provided dialect, then default, then auto-detect
                 effective_dialect = (
-                    dialect or self.default_dialect or self.detect_dialect(statement_sql)
+                    dialect or self.default_dialect or self.detect_dialect(stmt.raw)
                 )
 
                 # Parse the single statement
                 parsed = sqlglot.parse_one(
-                    statement_sql,
+                    stmt.raw,
                     dialect=effective_dialect,
                     error_level=sqlglot.errors.ErrorLevel.WARN,
                 )
 
                 # Create Query object
                 query = Query(
-                    raw=statement_sql,
+                    raw=stmt.raw,
                     normalized=self.normalize(parsed, dialect=effective_dialect),
                     dialect=effective_dialect or "unknown",
                     location=Location(
-                        line=location[0],
-                        column=location[1],
+                        line=stmt.line,
+                        column=stmt.column,
                         file=str(file_path) if file_path else None,
                         query_index=i,
                     ),
+                    start_offset=stmt.start_offset,
+                    end_offset=stmt.end_offset,
                     ast=parsed,
                     tables=tuple(self._extract_tables_from_ast(parsed)),
                     columns=tuple(self._extract_columns_from_ast(parsed)),
@@ -115,7 +124,7 @@ class UniversalParser(BaseParser):
             except SqlglotParseError as e:
                 raise ParseError(
                     f"Failed to parse SQL statement: {e}",
-                    sql=statement_sql,
+                    sql=stmt.raw,
                     details=str(e),
                 ) from e
 

--- a/tests/unit/test_parser_source_mapping.py
+++ b/tests/unit/test_parser_source_mapping.py
@@ -1,0 +1,104 @@
+# tests/unit/test_parser_source_mapping.py
+from slowql.parser.universal import UniversalParser
+
+
+def test_single_statement_preserves_raw_and_offsets():
+    sql = "SELECT * FROM users"
+    parser = UniversalParser()
+    queries = parser.parse(sql)
+
+    assert len(queries) == 1
+    query = queries[0]
+    assert query.raw == "SELECT * FROM users"
+    assert query.start_offset == 0
+    assert query.end_offset == 19
+    assert query.location.line == 1
+    assert query.location.column == 1
+
+def test_single_statement_with_semicolon():
+    sql = "SELECT 1;"
+    parser = UniversalParser()
+    queries = parser.parse(sql)
+
+    assert len(queries) == 1
+    query = queries[0]
+    assert query.raw == "SELECT 1;"
+    assert query.start_offset == 0
+    assert query.end_offset == 9
+    assert query.location.line == 1
+    assert query.location.column == 1
+
+def test_multiple_statements_splitting():
+    sql = "SELECT 1; SELECT 2 ;  SELECT 3"
+    parser = UniversalParser()
+    queries = parser.parse(sql)
+
+    assert len(queries) == 3
+
+    assert queries[0].raw == "SELECT 1;"
+    assert queries[0].start_offset == 0
+
+    assert queries[1].raw == "SELECT 2 ;"
+    assert queries[1].start_offset == 10
+
+    assert queries[2].raw == "SELECT 3"
+    assert queries[2].start_offset == 22
+
+def test_semicolon_inside_string_does_not_split():
+    sql = "SELECT 'a;b'; SELECT 2"
+    parser = UniversalParser()
+    queries = parser.parse(sql)
+
+    assert len(queries) == 2
+    assert queries[0].raw == "SELECT 'a;b';"
+    assert queries[1].raw == "SELECT 2"
+
+def test_comments_before_statement_are_excluded_from_raw():
+    sql = "-- line comment\n/* block \n comment */ SELECT 1"
+    parser = UniversalParser()
+    queries = parser.parse(sql)
+
+    assert len(queries) == 1
+    query = queries[0]
+    assert query.raw == "SELECT 1"
+    # SELECT starts after "-- line comment\n" (16 chars) and "/* block \n comment */ " (21 chars)
+    # Total prefix: 16 + 21 = 37 chars. 'S' is at offset 37.
+    assert query.start_offset == 38
+    assert query.location.line == 3
+    assert query.location.column == 13
+
+def test_multiple_statements_with_comments():
+    sql = """
+    -- first
+    SELECT 1;
+    /* second */
+    SELECT 2;
+    """
+    parser = UniversalParser()
+    queries = parser.parse(sql)
+
+    assert len(queries) == 2
+
+    assert queries[0].raw == "SELECT 1;"
+    assert queries[0].location.line == 3
+
+    assert queries[1].raw == "SELECT 2;"
+    assert queries[1].location.line == 5
+
+def test_semicolon_in_comments():
+    sql = "-- comment; \n SELECT 1; /* comment; */ SELECT 2"
+    parser = UniversalParser()
+    queries = parser.parse(sql)
+
+    assert len(queries) == 2
+    assert queries[0].raw == "SELECT 1;"
+    assert queries[1].raw == "SELECT 2"
+
+def test_trailing_whitespace_after_semicolon_is_excluded():
+    sql = "SELECT 1;   "
+    parser = UniversalParser()
+    queries = parser.parse(sql)
+
+    assert len(queries) == 1
+    assert queries[0].raw == "SELECT 1;"
+    assert queries[0].end_offset == 9  # Includes ';' but not '   '

--- a/tests/unit/test_parser_universal_extra.py
+++ b/tests/unit/test_parser_universal_extra.py
@@ -10,11 +10,10 @@ from slowql.parser.universal import UniversalParser
 
 class TestUniversalParserExtra:
     def test_parse_exception(self):
-        # Test that a generic Exception from sqlglot.parse is correctly wrapped into ParseError.
-        # The _split_statements method catches generic exceptions and re-raises them.
+        # Generic exceptions from statement splitting should be wrapped in ParseError.
         parser = UniversalParser()
         with (
-            patch("slowql.parser.universal.sqlglot.parse", side_effect=Exception("Boom")),
+            patch("slowql.parser.universal.SourceSplitter.split", side_effect=Exception("Boom")),
             pytest.raises(ParseError),
         ):
             parser.parse("SELECT 1")


### PR DESCRIPTION
## Summary

This PR adds source anchoring support to the parser layer so parsed queries retain exact source slices and offsets from the original SQL input.

## What changed

### Query model
- Added `start_offset`
- Added `end_offset`

### Parser
- `UniversalParser` now uses `SourceSplitter`
- parsed `Query.raw` now comes from exact source slices instead of regenerated SQL
- statement parse errors now reference `stmt.raw`
- generic source-splitting failures are wrapped in `ParseError`

### New parser utility
- Added `src/slowql/parser/source_splitter.py`
- preserves:
  - exact raw statement text
  - statement offsets
  - statement starting line/column
- handles semicolons safely outside strings/comments

### Tests
- Added parser source-mapping coverage
- updated parser exception test to reflect the new splitter-based architecture

## Why this matters

This is foundational for trustworthy span-based autofixes.

Previously, parsing could regenerate SQL text, causing a mismatch between:
- previewed fixes
- original file content

That prevented some safe context-sensitive fixes from being applied reliably.

With exact source anchoring in place, future autofixes can target original source text safely.

## Validation

```bash
pytest -q```

Result: 915 passing tests
