### PR TITLE
feat: add safe autofix for EXISTS subqueries using SELECT *

### DIFF
--- a/src/slowql/rules/catalog.py
+++ b/src/slowql/rules/catalog.py
@@ -2449,6 +2449,36 @@ class WildcardInColumnListRule(PatternRule):
         "SELECT 1 clearly signals intent and is universally optimized."
     )
 
+    def suggest_fix(self, query: Query) -> Fix | None:
+        """
+        Suggest a safe fix for SELECT * inside EXISTS subqueries.
+
+        The fix targets only the exact inner SELECT * span inside EXISTS(...).
+        """
+        match = re.search(self.pattern, query.raw, re.IGNORECASE)
+        if not match:
+            return None
+
+        segment = query.raw[match.start():]
+        select_match = re.search(r"(?i)\bSELECT\s+\*", segment)
+        if not select_match:
+            return None
+
+        span_start = match.start() + select_match.start()
+        span_end = match.start() + select_match.end()
+
+        return Fix(
+            description="Replace SELECT * with SELECT 1 inside EXISTS subquery",
+            original=query.raw[span_start:span_end],
+            replacement="SELECT 1",
+            confidence=FixConfidence.SAFE,
+            rule_id=self.id,
+            is_safe=True,
+            start=span_start,
+            end=span_end,
+        )
+
+
 class DuplicateConditionRule(PatternRule):
     """Detects obvious duplicate WHERE conditions."""
 

--- a/src/slowql/rules/quality/style.py
+++ b/src/slowql/rules/quality/style.py
@@ -4,7 +4,9 @@ Quality Style rules.
 
 from __future__ import annotations
 
-from slowql.core.models import Category, Dimension, Severity
+import re
+
+from slowql.core.models import Category, Dimension, Fix, FixConfidence, Query, Severity
 from slowql.rules.base import PatternRule
 
 __all__ = [
@@ -69,6 +71,36 @@ class WildcardInColumnListRule(PatternRule):
         "Replace 'EXISTS (SELECT * FROM ...)' with 'EXISTS (SELECT 1 FROM ...)'. "
         "SELECT 1 clearly signals intent and is universally optimized."
     )
+
+    def suggest_fix(self, query: Query) -> Fix | None:
+        """
+        Suggest a safe fix for SELECT * inside EXISTS subqueries.
+
+        The fix targets only the exact inner SELECT * span inside EXISTS(...).
+        """
+        match = re.search(self.pattern, query.raw, re.IGNORECASE)
+        if not match:
+            return None
+
+        segment = query.raw[match.start():]
+        select_match = re.search(r"(?i)\bSELECT\s+\*", segment)
+        if not select_match:
+            return None
+
+        span_start = match.start() + select_match.start()
+        span_end = match.start() + select_match.end()
+
+        return Fix(
+            description="Replace SELECT * with SELECT 1 inside EXISTS subquery",
+            original=query.raw[span_start:span_end],
+            replacement="SELECT 1",
+            confidence=FixConfidence.SAFE,
+            rule_id=self.id,
+            is_safe=True,
+            start=span_start,
+            end=span_end,
+        )
+
 
 class MissingAliasRule(PatternRule):
     """Detects subqueries in FROM without an alias."""

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -1547,6 +1547,38 @@ class TestWildcardInColumnListRule:
     def test_regular_select_star(self):
         assert not self.rule.check(_make_query("SELECT * FROM users"))
 
+    def test_suggest_fix_exists_select_star(self):
+        sql = "SELECT id FROM users WHERE EXISTS (SELECT * FROM orders WHERE orders.user_id = users.id)"
+        query = _make_query(sql)
+        fix = self.rule.suggest_fix(query)
+        assert fix is not None
+        assert fix.confidence == FixConfidence.SAFE
+        assert fix.rule_id == "QUAL-STYLE-002"
+        assert fix.original == "SELECT *"
+        assert fix.replacement == "SELECT 1"
+        assert fix.is_safe is True
+        assert fix.start is not None
+        assert fix.end is not None
+        assert sql[fix.start:fix.end] == "SELECT *"
+
+    def test_suggest_fix_exists_select_one(self):
+        query = _make_query(
+            "SELECT id FROM users WHERE EXISTS (SELECT 1 FROM orders WHERE orders.user_id = users.id)"
+        )
+        fix = self.rule.suggest_fix(query)
+        assert fix is None
+
+    def test_suggest_fix_targets_inner_select_star_only(self):
+        sql = "SELECT * FROM users WHERE EXISTS (SELECT * FROM orders WHERE orders.user_id = users.id)"
+        query = _make_query(sql)
+        fix = self.rule.suggest_fix(query)
+        assert fix is not None
+        assert fix.original == "SELECT *"
+        assert fix.start is not None
+        assert fix.end is not None
+        assert sql[fix.start:fix.end] == "SELECT *"
+        assert fix.start > 0
+
 
 class TestDuplicateConditionRule:
     def setup_method(self):


### PR DESCRIPTION
## Summary

This PR adds the second real safe autofix to SlowQL:

- `QUAL-STYLE-002`
- `EXISTS (SELECT *)` → `EXISTS (SELECT 1)`

## What changed

- Added `suggest_fix()` to `WildcardInColumnListRule`
  - in `src/slowql/rules/catalog.py`
  - in `src/slowql/rules/quality/style.py`
- The fix is span-based and targets only the exact inner `SELECT *`
- Added regression tests to `tests/unit/test_rules.py`

## Safety

This autofix is considered SAFE because:
- inside `EXISTS (...)`, the projection list is semantically ignored
- only the exact inner `SELECT *` span is replaced
- outer `SELECT *` is not touched
- source-anchored spans are used for precise patching

## Validation

- `ruff` passes
- `mypy src/slowql` passes
- `pytest tests/unit/test_rules.py -q --no-cov` passes
- end-to-end CLI preview and apply behavior verified manually

## Manual smoke result

Preview:
- showed `SELECT *` → `SELECT 1` inside EXISTS

Apply:
- updated file correctly
- created `.bak` backup
- preserved original file in backup