### PR TITLE
feat: add remediation mode classification for rules

### DIFF
--- a/src/slowql/core/models.py
+++ b/src/slowql/core/models.py
@@ -261,6 +261,14 @@ class FixConfidence(str, Enum):
     UNSAFE = "unsafe"
 
 
+class RemediationMode(str, Enum):
+    """How a rule should be remediated by default."""
+
+    SAFE_APPLY = "safe_apply"
+    PREVIEW_ONLY = "preview_only"
+    GUIDANCE_ONLY = "guidance_only"
+
+
 @dataclass(frozen=True, slots=True)
 class Location:
     """

--- a/src/slowql/rules/base.py
+++ b/src/slowql/rules/base.py
@@ -22,6 +22,7 @@ from slowql.core.models import (
     Fix,
     Issue,
     Location,
+    RemediationMode,
     Severity,
 )
 from slowql.rules.registry import RuleRegistry, get_rule_registry
@@ -138,6 +139,7 @@ class Rule(ABC):
     severity: ClassVar[Severity] = Severity.MEDIUM
     dimension: ClassVar[Dimension] = Dimension.QUALITY
     category: ClassVar[Category | None] = None
+    remediation_mode: ClassVar[RemediationMode] = RemediationMode.GUIDANCE_ONLY
     enabled: ClassVar[bool] = True
     tags: ClassVar[tuple[str, ...]] = ()
 
@@ -496,6 +498,7 @@ def create_rule(
     DynamicRule.severity = severity
     DynamicRule.dimension = dimension
     DynamicRule.category = category
+    DynamicRule.remediation_mode = RemediationMode.GUIDANCE_ONLY
     DynamicRule.enabled = enabled
     DynamicRule.tags = tags
     DynamicRule.impact = impact

--- a/src/slowql/rules/quality/null_handling.py
+++ b/src/slowql/rules/quality/null_handling.py
@@ -4,7 +4,15 @@ Quality Null handling rules.
 
 from __future__ import annotations
 
-from slowql.core.models import Category, Dimension, Fix, FixConfidence, Query, Severity
+from slowql.core.models import (
+    Category,
+    Dimension,
+    Fix,
+    FixConfidence,
+    Query,
+    RemediationMode,
+    Severity,
+)
 from slowql.rules.base import PatternRule
 
 __all__ = [
@@ -25,6 +33,7 @@ class NullComparisonRule(PatternRule):
     severity = Severity.HIGH
     dimension = Dimension.QUALITY
     category = Category.QUAL_READABILITY
+    remediation_mode = RemediationMode.SAFE_APPLY
 
     pattern = (
         r"(?<![A-Z_])\s*=\s*NULL\b"

--- a/src/slowql/rules/quality/style.py
+++ b/src/slowql/rules/quality/style.py
@@ -6,7 +6,15 @@ from __future__ import annotations
 
 import re
 
-from slowql.core.models import Category, Dimension, Fix, FixConfidence, Query, Severity
+from slowql.core.models import (
+    Category,
+    Dimension,
+    Fix,
+    FixConfidence,
+    Query,
+    RemediationMode,
+    Severity,
+)
 from slowql.rules.base import PatternRule
 
 __all__ = [
@@ -59,6 +67,7 @@ class WildcardInColumnListRule(PatternRule):
     severity = Severity.INFO
     dimension = Dimension.QUALITY
     category = Category.QUAL_READABILITY
+    remediation_mode = RemediationMode.SAFE_APPLY
 
     pattern = r"\bEXISTS\s*\(\s*SELECT\s+\*"
     message_template = "SELECT * inside EXISTS subquery — use SELECT 1 instead: {match}"


### PR DESCRIPTION
## Summary

This PR introduces a remediation classification layer for SlowQL rules.

## What changed

### New remediation policy enum
Added `RemediationMode` with:
- `SAFE_APPLY`
- `PREVIEW_ONLY`
- `GUIDANCE_ONLY`

### Rule base default
All rules now default to:
- `GUIDANCE_ONLY`

### Safe rules explicitly marked
The currently trusted safe autofix rules are marked as:
- `QUAL-NULL-001` → `SAFE_APPLY`
- `QUAL-STYLE-002` → `SAFE_APPLY`

## Why this matters

This establishes a consistent remediation policy model for future autofix work.

Instead of treating all fixes equally, SlowQL now has an explicit classification system that can later drive:
- CLI autofix behavior
- preview vs apply decisions
- CI policy
- UI messaging
- future GitHub Action behavior

## Validation

- `ruff` passes
- `mypy src/slowql` passes
- full test suite passes (`918 passed`)