### PR TITLE
feat: add fix report output for diff and apply modes

### DIFF
--- a/src/slowql/cli/app.py
+++ b/src/slowql/cli/app.py
@@ -212,17 +212,17 @@ def _run_exports(result: AnalysisResult, formats: list[str], out_dir: Path) -> N
 
 def _collect_safe_fixes(
     engine: SlowQL, result: AnalysisResult
-) -> list[tuple[Query, list[Fix]]]:
+) -> list[tuple[Query, list[tuple[Fix, str | None]]]]:
     """
     Collect SAFE fixes for rules that actually matched each query.
 
     Returns:
-        A list of (query, fixes) pairs.
+        A list of (query, fixes_with_mode) pairs.
     """
-    collected: list[tuple[Query, list[Fix]]] = []
+    collected: list[tuple[Query, list[tuple[Fix, str | None]]]] = []
 
     for query in result.queries:
-        safe_fixes: list[Fix] = []
+        safe_fixes: list[tuple[Fix, str | None]] = []
         seen: set[tuple[str, str, str, str]] = set()
 
         for analyzer in engine.analyzers:
@@ -243,7 +243,10 @@ def _collect_safe_fixes(
                 if key in seen:
                     continue
                 seen.add(key)
-                safe_fixes.append(fix)
+
+                rmode = getattr(rule, "remediation_mode", None)
+                rmode_val = rmode.value if rmode else None
+                safe_fixes.append((fix, rmode_val))
 
         if safe_fixes:
             collected.append((query, safe_fixes))
@@ -251,7 +254,12 @@ def _collect_safe_fixes(
     return collected
 
 
-def _preview_safe_fixes(engine: SlowQL, result: AnalysisResult) -> None:
+def _preview_safe_fixes(
+    engine: SlowQL,
+    result: AnalysisResult,
+    fix_report: Path | None = None,
+    input_file: Path | None = None,
+) -> None:
     """
     Preview SAFE autofixes for rules that matched the analyzed queries.
 
@@ -261,7 +269,11 @@ def _preview_safe_fixes(engine: SlowQL, result: AnalysisResult) -> None:
     autofixer = AutoFixer()
     any_preview = False
 
-    for idx, (query, safe_fixes) in enumerate(_collect_safe_fixes(engine, result), start=1):
+    all_safe_fixes_with_modes: list[tuple[Fix, str | None]] = []
+
+    for idx, (query, safe_fixes_with_modes) in enumerate(_collect_safe_fixes(engine, result), start=1):
+        safe_fixes = [f for f, m in safe_fixes_with_modes]
+        all_safe_fixes_with_modes.extend(safe_fixes_with_modes)
         diff = autofixer.preview_fixes(query.raw, safe_fixes)
         if not diff:
             continue
@@ -278,6 +290,49 @@ def _preview_safe_fixes(engine: SlowQL, result: AnalysisResult) -> None:
 
     if not any_preview:
         console.print("[dim]No safe autofix preview available for the analyzed query/queries.[/dim]")
+
+    if fix_report is not None:
+        assert fix_report is not None
+        _write_fix_report(
+            path=fix_report,
+            mode="diff",
+            fixes_with_modes=all_safe_fixes_with_modes,
+            input_file=input_file,
+            backup_file=None,
+        )
+
+
+def _write_fix_report(
+    path: Path,
+    mode: str,
+    fixes_with_modes: list[tuple[Fix, str | None]],
+    input_file: Path | None,
+    backup_file: Path | None,
+) -> None:
+    data = {
+        "mode": mode,
+        "timestamp": datetime.now().isoformat(),
+        "input_file": str(input_file) if input_file else None,
+        "backup_file": str(backup_file) if backup_file else None,
+        "total_fixes": len(fixes_with_modes),
+        "fixes": [
+            {
+                "rule_id": f.rule_id,
+                "description": f.description,
+                "confidence": f.confidence.value if isinstance(f.confidence, FixConfidence) else f.confidence,
+                "remediation_mode": rm,
+                "original": f.original,
+                "replacement": f.replacement,
+                "start": f.start,
+                "end": f.end,
+                "is_safe": f.is_safe,
+            }
+            for f, rm in fixes_with_modes
+        ]
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as file:
+        json.dump(data, file, indent=2)
 
 
 def show_quick_actions_menu(
@@ -621,6 +676,7 @@ def _apply_safe_fixes_to_file(
     sql_payload: str,
     engine: SlowQL,
     result: AnalysisResult,
+    fix_report: Path | None = None,
 ) -> None:
     """
     Apply SAFE fixes to a single input file.
@@ -636,7 +692,8 @@ def _apply_safe_fixes_to_file(
 
     autofixer = AutoFixer()
     collected = _collect_safe_fixes(engine, result)
-    all_safe_fixes = [fix for _, fixes in collected for fix in fixes]
+    all_safe_fixes_with_modes = [fm for _, fixes in collected for fm in fixes]
+    all_safe_fixes = [f for f, m in all_safe_fixes_with_modes]
 
     if not all_safe_fixes:
         console.print("[dim]No safe fixes available to apply.[/dim]")
@@ -647,9 +704,19 @@ def _apply_safe_fixes_to_file(
         console.print("[dim]No applicable safe fixes were applied.[/dim]")
         return
 
+    assert input_file is not None
     backup_path = input_file.with_name(input_file.name + ".bak")
     backup_path.write_text(sql_payload, encoding="utf-8")
     input_file.write_text(updated, encoding="utf-8")
+
+    if fix_report:
+        _write_fix_report(
+            path=fix_report,
+            mode="fix",
+            fixes_with_modes=all_safe_fixes_with_modes,
+            input_file=input_file,
+            backup_file=backup_path,
+        )
 
     console.print(f"[green]✓ Applied safe fixes:[/green] {input_file}")
     console.print(f"[green]✓ Backup created:[/green] {backup_path}")
@@ -667,6 +734,7 @@ def _handle_result_output(
     input_file: Path | None,
     sql_payload: str,
     apply_fixes: bool,
+    fix_report: Path | None = None,
 ) -> bool:
     """
     Handle result reporting, preview, optional exports, and loop continuation.
@@ -679,7 +747,7 @@ def _handle_result_output(
     formatter.report(result)
 
     if show_diff:
-        _preview_safe_fixes(engine, result)
+        _preview_safe_fixes(engine, result, fix_report, input_file)
 
     if apply_fixes:
         _apply_safe_fixes_to_file(
@@ -687,6 +755,7 @@ def _handle_result_output(
             sql_payload=sql_payload,
             engine=engine,
             result=result,
+            fix_report=fix_report,
         )
 
     if export_formats:
@@ -766,6 +835,7 @@ def run_analysis_loop(
     export_session_history: bool = False,
     apply_fixes: bool = False,
     fail_on: str | None = None,
+    fix_report: Path | None = None,
 ) -> int:
     """
     Main execution pipeline with interactive loop
@@ -829,6 +899,7 @@ def run_analysis_loop(
                 input_file=input_file,
                 sql_payload=sql_payload,
                 apply_fixes=apply_fixes,
+                fix_report=fix_report,
             ):
                 break
 
@@ -931,6 +1002,11 @@ def build_argparser() -> argparse.ArgumentParser:
         action="store_true",
         help="Export session history explicitly (especially for non-interactive mode)",
     )
+    output_group.add_argument(
+        "--fix-report",
+        type=Path,
+        help="Write JSON report of previewed or applied safe fixes",
+    )
 
     # UI options
     ui_group = p.add_argument_group("UI Options")
@@ -979,7 +1055,7 @@ def main(argv: list[str] | None = None) -> int:
             parser.error("--fix currently supports only a single file, not a directory")
 
     # Run analysis loop
-    loop_kwargs = {
+    loop_kwargs: dict[str, Any] = {
         "intro_enabled": not args.no_intro,
         "intro_duration": args.duration,
         "mode": args.mode,
@@ -1003,6 +1079,10 @@ def main(argv: list[str] | None = None) -> int:
     fail_on = args_dict.get("fail_on", None)
     if fail_on:
         loop_kwargs["fail_on"] = fail_on
+
+    fix_report = args_dict.get("fix_report", None)
+    if fix_report:
+        loop_kwargs["fix_report"] = fix_report
 
     return run_analysis_loop(**loop_kwargs)
 

--- a/src/slowql/rules/catalog.py
+++ b/src/slowql/rules/catalog.py
@@ -27,6 +27,7 @@ from slowql.core.models import (
     FixConfidence,
     Issue,
     Query,
+    RemediationMode,
     Severity,
 )
 from slowql.rules.base import ASTRule, PatternRule, Rule
@@ -2300,6 +2301,7 @@ class NullComparisonRule(PatternRule):
     severity = Severity.HIGH
     dimension = Dimension.QUALITY
     category = Category.QUAL_READABILITY
+    remediation_mode = RemediationMode.SAFE_APPLY
 
     pattern = (
         r"(?<![A-Z_])\s*=\s*NULL\b"
@@ -2436,6 +2438,7 @@ class WildcardInColumnListRule(PatternRule):
     severity = Severity.INFO
     dimension = Dimension.QUALITY
     category = Category.QUAL_READABILITY
+    remediation_mode = RemediationMode.SAFE_APPLY
 
     pattern = r"\bEXISTS\s*\(\s*SELECT\s+\*"
     message_template = "SELECT * inside EXISTS subquery — use SELECT 1 instead: {match}"

--- a/tests/unit/test_cli_autofix.py
+++ b/tests/unit/test_cli_autofix.py
@@ -128,3 +128,73 @@ def test_fix_applies_safe_null_fix_and_creates_backup(tmp_path, monkeypatch):
     backup_file = tmp_path / "query.sql.bak"
     assert backup_file.exists()
     assert backup_file.read_text(encoding="utf-8") == original
+
+def test_diff_with_fix_report(tmp_path):
+    sql_file = tmp_path / "query.sql"
+    sql_file.write_text("SELECT * FROM users WHERE deleted_at = NULL;\n", encoding="utf-8")
+    report_file = tmp_path / "report.json"
+
+    cli_app.main([
+        "--non-interactive", "--no-intro",
+        "--input-file", str(sql_file),
+        "--diff",
+        "--fix-report", str(report_file)
+    ])
+
+    import json
+    assert report_file.exists()
+    data = json.loads(report_file.read_text(encoding="utf-8"))
+    assert data["mode"] == "diff"
+    assert data["input_file"] == str(sql_file.resolve())
+    assert data["backup_file"] is None
+    assert data["total_fixes"] > 0
+    fix = data["fixes"][0]
+    assert "remediation_mode" in fix
+    assert fix["remediation_mode"] == "safe_apply"
+    assert fix["is_safe"] is True
+    assert fix["rule_id"] == "QUAL-NULL-001"
+
+
+def test_fix_with_fix_report(tmp_path, monkeypatch):
+    sql_file = tmp_path / "query.sql"
+    sql_file.write_text("SELECT * FROM users WHERE deleted_at = NULL;\n", encoding="utf-8")
+    report_file = tmp_path / "report.json"
+
+    def fail_if_export_called(_self, _filename=None):
+        raise AssertionError("session export should not be called without --export-session")
+
+    monkeypatch.setattr(cli_app.SessionManager, "export_session", fail_if_export_called)
+
+    cli_app.main([
+        "--non-interactive", "--no-intro",
+        "--input-file", str(sql_file),
+        "--fix",
+        "--fix-report", str(report_file)
+    ])
+
+    import json
+    assert report_file.exists()
+    data = json.loads(report_file.read_text(encoding="utf-8"))
+    assert data["mode"] == "fix"
+    assert data["input_file"] == str(sql_file.resolve())
+    assert data["backup_file"] == str(sql_file.with_name(sql_file.name + ".bak").resolve())
+    assert data["total_fixes"] > 0
+    fix = data["fixes"][0]
+    assert "remediation_mode" in fix
+    assert fix["remediation_mode"] == "safe_apply"
+    assert fix["is_safe"] is True
+    assert fix["rule_id"] == "QUAL-NULL-001"
+
+
+def test_no_fix_report_created_unless_explicitly_passed(tmp_path):
+    sql_file = tmp_path / "query.sql"
+    sql_file.write_text("SELECT * FROM users WHERE deleted_at = NULL;\n", encoding="utf-8")
+    report_file = tmp_path / "should_not_exist.json"
+
+    cli_app.main([
+        "--non-interactive", "--no-intro",
+        "--input-file", str(sql_file),
+        "--diff"
+    ])
+
+    assert not report_file.exists()


### PR DESCRIPTION
## Summary

This PR adds optional machine-readable fix report output for SlowQL autofix preview and apply flows.

## What changed

### New CLI flag
- `--fix-report PATH`

### Behavior
- For `--diff`, writes a JSON report of previewed safe fixes
- For `--fix`, writes a JSON report of applied safe fixes

### Report fields
The report includes:
- mode
- timestamp
- input_file
- backup_file
- total_fixes
- fixes:
  - rule_id
  - description
  - confidence
  - remediation_mode
  - original
  - replacement
  - start
  - end
  - is_safe

### Additional behavior
- no report file is created unless `--fix-report` is explicitly passed
- diff reports include `input_file` when available
- apply reports include backup file path when a backup is created

## Validation

- `ruff` passes
- `mypy src/slowql/cli/app.py` passes
- targeted CLI autofix tests pass
- full suite passes (`921 passed`)