### PR TITLE
feat: add official pre-commit hook metadata

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: slowql
+  name: SlowQL
+  description: "Analyze SQL files for anti-patterns and code quality issues"
+  entry: slowql --non-interactive
+  language: python
+  types: [sql]
+  pass_filenames: true

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ repos:
     rev: v1.5.0
     hooks:
       - id: slowql
-        args: ["--non-interactive", "--fail-on", "medium"]
+        args: ["--fail-on", "medium"]
 ```
 
 ---


### PR DESCRIPTION
## Summary

This PR adds first-class pre-commit support for SlowQL.

## What changed

- added `.pre-commit-hooks.yaml`
- configured the `slowql` hook to run non-interactively
- enabled `pass_filenames: true`
- updated README pre-commit example to match the actual hook behavior

## Validation

- reviewed hook metadata
- verified with `pre-commit try-repo`
- README example aligned with real hook configuration