### PR TITLE
feat: add SARIF output support

### DIFF
--- a/src/slowql/cli/app.py
+++ b/src/slowql/cli/app.py
@@ -44,8 +44,9 @@ from slowql.reporters.base import BaseReporter
 from slowql.reporters.console import ConsoleReporter
 from slowql.reporters.github_actions_reporter import GithubActionsReporter
 from slowql.reporters.json_reporter import CSVReporter, HTMLReporter, JSONReporter
+from slowql.reporters.sarif_reporter import SARIFReporter
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.ERROR)
 logger = logging.getLogger("slowql")
 
 console = Console()
@@ -60,6 +61,7 @@ class SessionManager:
         self.session_start = datetime.now()
         self.history: list[dict[str, Any]] = []
         self.severity_breakdown = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+        self._machine_readable = False
 
     def add_analysis(self, result: AnalysisResult) -> None:
         """Record an analysis run"""
@@ -152,9 +154,16 @@ class QueryCache:
         self.cache.clear()
 
 
-def init_cli() -> None:
+def init_cli(machine_readable: bool = False) -> None:
     """Initialize CLI logging."""
-    logger.info("SlowQL CLI started")
+    if not machine_readable:
+        logger.setLevel(logging.INFO)
+        logger.info("SlowQL CLI started")
+    else:
+        # Mute all logging in machine readable mode so it doesn't corrupt stdout
+        logging.getLogger().setLevel(logging.CRITICAL)
+        logging.getLogger("sqlglot").setLevel(logging.CRITICAL)
+        logger.setLevel(logging.CRITICAL)
 
 
 # -------------------------------
@@ -206,6 +215,12 @@ def _run_exports(result: AnalysisResult, formats: list[str], out_dir: Path) -> N
                 with path.open("w", encoding="utf-8", newline="") as f:
                     CSVReporter(output_file=f).report(result)
                 console.print(f"[green]✓ Exported CSV:[/green] {path}")
+
+            elif fmt == "sarif":
+                path = out_dir / f"slowql_report_{timestamp}.sarif"
+                with path.open("w", encoding="utf-8") as f:
+                    SARIFReporter(output_file=f).report(result)
+                console.print(f"[green]✓ Exported SARIF:[/green] {path}")
 
         except Exception as e:
             console.print(f"[red]✗ Failed to export {fmt}:[/red] {e}")
@@ -429,7 +444,8 @@ def export_interactive(result: AnalysisResult, out_dir: Path) -> None:
         ("📄 JSON", ["json"]),
         ("🌐 HTML", ["html"]),
         ("📑 CSV", ["csv"]),
-        ("🧰 All (JSON + HTML + CSV)", ["json", "html", "csv"]),
+        ("🛡️ SARIF", ["sarif"]),
+        ("🧰 All (JSON + HTML + CSV + SARIF)", ["json", "html", "csv", "sarif"]),
     ]
     index = 0
 
@@ -461,7 +477,7 @@ def export_interactive(result: AnalysisResult, out_dir: Path) -> None:
     # Fallback to numeric prompt if readchar isn't available
     if not HAVE_READCHAR or not sys.stdin.isatty():
         console.print(render_menu())
-        choice = Prompt.ask("Select format [1/2/3/4]", choices=["1", "2", "3", "4"], default="1")
+        choice = Prompt.ask("Select format [1/2/3/4/5]", choices=["1", "2", "3", "4", "5"], default="1")
         _run_exports(result, options[int(choice) - 1][1], out_dir)
         return
 
@@ -584,31 +600,35 @@ def _get_sql_input(
 
 
 def _run_analysis(
-    sql_payload: str, engine: SlowQL, cache: QueryCache | None, fast: bool
+    sql_payload: str, engine: SlowQL, cache: QueryCache | None, fast: bool, machine_readable: bool = False
 ) -> AnalysisResult | None:
     """Runs analysis, using cache if available, with animations."""
     result = None
     if cache:
         result = cache.get(sql_payload)
-        if result is not None:
+        if result is not None and not machine_readable:
             console.print("[dim]Using cached results...[/dim]")
 
     if result is None:
-        aa = AnimatedAnalyzer()
-        with contextlib.suppress(Exception):
-            if not fast:
-                aa.particle_loading("ANALYZING QUERIES")
-                aa.glitch_transition(duration=0.25)
-
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            console=console,
-        ) as progress:
-            task = progress.add_task("[cyan]Analyzing...", total=1)
+        if machine_readable:
+            # Just run the analysis synchronously with no feedback
             result = engine.analyze(sql_payload)
-            progress.update(task, advance=1)
+        else:
+            aa = AnimatedAnalyzer()
+            with contextlib.suppress(Exception):
+                if not fast:
+                    aa.particle_loading("ANALYZING QUERIES")
+                    aa.glitch_transition(duration=0.25)
+
+            with Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                BarColumn(),
+                console=console,
+            ) as progress:
+                task = progress.add_task("[cyan]Analyzing...", total=1)
+                result = engine.analyze(sql_payload)
+                progress.update(task, advance=1)
 
         if cache and result:
             cache.set(sql_payload, result)
@@ -616,8 +636,11 @@ def _run_analysis(
     return result
 
 
-def _show_intro(intro_enabled: bool, fast: bool, is_tty: bool, intro_duration: float) -> None:
+def _show_intro(intro_enabled: bool, fast: bool, is_tty: bool, intro_duration: float, machine_readable: bool = False) -> None:
     """Displays the intro animation and welcome banner."""
+    if machine_readable:
+        return
+
     if intro_enabled and not fast and is_tty:
         with contextlib.suppress(Exception):
             MatrixRain().run(duration=intro_duration)
@@ -768,7 +791,13 @@ def _handle_result_output(
         True if analysis should continue, False if loop should stop.
     """
     session.add_analysis(result)
-    console.print("\n")
+
+    machine_readable = isinstance(formatter, SARIFReporter) and not out_dir
+    machine_readable = machine_readable or (hasattr(formatter, "output_file") and formatter.output_file is None)
+
+    if not machine_readable:
+        console.print("\n")
+
     formatter.report(result)
 
     if show_diff:
@@ -825,8 +854,9 @@ def _handle_loop_end(
         if not show_quick_actions_menu(result, None, out_dir):
             return False  # Break loop
     else:
-        console.print("\n")
-        session.display_summary()
+        if not hasattr(session, "_machine_readable") or not session._machine_readable:
+            console.print("\n")
+            session.display_summary()
 
         # Export session only when explicitly requested
         if export_session_history:
@@ -881,13 +911,18 @@ def run_analysis_loop(  # noqa: PLR0912, PLR0915
     formatter: BaseReporter
     if report_format == "github-actions":
         formatter = GithubActionsReporter()
+    elif report_format == "sarif":
+        formatter = SARIFReporter()
     else:
         formatter = ConsoleReporter()
 
     out_dir = safe_path(out_dir)
 
+    machine_readable = report_format == "sarif"
+    session._machine_readable = machine_readable
+
     is_tty = sys.stdin.isatty() and sys.stdout.isatty()
-    _show_intro(intro_enabled, fast, is_tty, intro_duration)
+    _show_intro(intro_enabled, fast, is_tty, intro_duration, machine_readable=machine_readable)
 
     first_run = True
     current_input_files: list[Path] | None = initial_input_files
@@ -913,7 +948,7 @@ def run_analysis_loop(  # noqa: PLR0912, PLR0915
                 continue
 
             first_run = False
-            result = _run_analysis(sql_payload, engine, cache, fast)
+            result = _run_analysis(sql_payload, engine, cache, fast, machine_readable=machine_readable)
             if not result:
                 continue
 
@@ -951,16 +986,17 @@ def run_analysis_loop(  # noqa: PLR0912, PLR0915
                 break
 
     # Final message
-    console.print("\n")
-    console.print(
-        Panel(
-            "[bold green]Thank you for using SlowQL![/bold green]\n"
-            f"[dim]Analyzed {session.queries_analyzed} queries | "
-            f"Found {session.total_issues} issues[/dim]",
-            border_style="green",
-            box=box.DOUBLE,
+    if not machine_readable:
+        console.print("\n")
+        console.print(
+            Panel(
+                "[bold green]Thank you for using SlowQL![/bold green]\n"
+                f"[dim]Analyzed {session.queries_analyzed} queries | "
+                f"Found {session.total_issues} issues[/dim]",
+                border_style="green",
+                box=box.DOUBLE,
+            )
         )
-    )
 
     return highest_exit_code
 
@@ -1016,14 +1052,14 @@ def build_argparser() -> argparse.ArgumentParser:
     output_group = p.add_argument_group("Output Options")
     output_group.add_argument(
         "--format",
-        choices=["console", "github-actions"],
+        choices=["console", "github-actions", "sarif"],
         default="console",
         help="Output format for analysis results (default: console)",
     )
     output_group.add_argument(
         "--export",
         nargs="*",
-        choices=["html", "csv", "json"],
+        choices=["html", "csv", "json", "sarif"],
         help="Auto-export formats after each analysis",
     )
     output_group.add_argument(
@@ -1076,7 +1112,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: PLR0912, PLR0915
     """
     Enhanced CLI entry point with analysis loop
     """
-    init_cli()
+
     parser = build_argparser()
     args = parser.parse_args(argv)
 
@@ -1109,6 +1145,9 @@ def main(argv: list[str] | None = None) -> int:  # noqa: PLR0912, PLR0915
     diff_enabled = bool(args_dict.get("diff", False))
     fix_enabled = bool(args_dict.get("fix", False))
     export_session_enabled = bool(args_dict.get("export_session", False))
+    report_format = args_dict.get("format", None)
+
+    init_cli(machine_readable=(report_format == "sarif"))
 
     if diff_enabled and fix_enabled:
         parser.error("--diff and --fix cannot be used together")

--- a/src/slowql/reporters/sarif_reporter.py
+++ b/src/slowql/reporters/sarif_reporter.py
@@ -1,0 +1,118 @@
+# slowql/src/slowql/reporters/sarif_reporter.py
+"""
+SARIF reporter for SlowQL.
+
+Outputs the full analysis result as a structured SARIF 2.1.0 JSON object.
+Useful for integrating with code scanning and security tooling.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from slowql.core.models import Severity
+from slowql.reporters.base import BaseReporter
+
+if TYPE_CHECKING:
+    from slowql.core.models import AnalysisResult
+
+
+class SARIFReporter(BaseReporter):
+    """
+    Renders analysis results as SARIF 2.1.0 JSON.
+    """
+
+    def _map_severity(self, severity: Severity) -> str:
+        """Map SlowQL severity to SARIF level."""
+        if severity in (Severity.CRITICAL, Severity.HIGH):
+            return "error"
+        if severity == Severity.MEDIUM:
+            return "warning"
+        if severity in (Severity.LOW, Severity.INFO):
+            return "note"
+        return "none"
+
+    def report(self, result: AnalysisResult) -> None:
+        """
+        Convert result to SARIF and write to output.
+        """
+        rules_dict: dict[str, dict[str, Any]] = {}
+        sarif_results: list[dict[str, Any]] = []
+
+        for issue in result.issues:
+            rule_id = issue.rule_id
+
+            # Build rule metadata if not already present
+            if rule_id not in rules_dict:
+                rules_dict[rule_id] = {
+                    "id": rule_id,
+                    "name": rule_id.replace("-", ""),
+                    "shortDescription": {"text": getattr(issue, "message", "Rule violation")},
+                    "properties": {
+                        "category": issue.dimension.name if hasattr(issue, "dimension") and hasattr(issue.dimension, "name") else str(getattr(issue, "dimension", ""))
+                    }
+                }
+
+            level = self._map_severity(issue.severity)
+
+            sarif_result: dict[str, Any] = {
+                "ruleId": rule_id,
+                "message": {"text": issue.message},
+                "level": level,
+            }
+
+            # Map locations if available
+            if issue.location:
+                loc = issue.location
+                file_path = loc.file if loc.file else "unknown"
+
+                physical_loc: dict[str, Any] = {
+                    "artifactLocation": {"uri": file_path}
+                }
+
+                region: dict[str, int] = {}
+                if loc.line:
+                    region["startLine"] = loc.line
+                if loc.end_line:
+                    region["endLine"] = loc.end_line
+                if loc.column:
+                    region["startColumn"] = loc.column
+                if loc.end_column:
+                    region["endColumn"] = loc.end_column
+
+                if region:
+                    physical_loc["region"] = region
+
+                sarif_result["locations"] = [{"physicalLocation": physical_loc}]
+
+            sarif_results.append(sarif_result)
+
+        sarif_log = {
+            "version": "2.1.0",
+            "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "SlowQL",
+                            "informationUri": "https://github.com/slowql/slowql",
+                            "version": result.version,
+                            "rules": list(rules_dict.values())
+                        }
+                    },
+                    "results": sarif_results
+                }
+            ]
+        }
+
+        sarif_output = json.dumps(
+            sarif_log,
+            indent=2,
+            ensure_ascii=False,
+        )
+
+        if self.output_file:
+            self.output_file.write(sarif_output)
+        else:
+            print(sarif_output)

--- a/tests/unit/test_cli_app.py
+++ b/tests/unit/test_cli_app.py
@@ -321,7 +321,7 @@ class TestExportFunctions:
     @patch("slowql.cli.app.Prompt")
     def test_export_interactive_all_fallback(self, mock_prompt, _mock_console, mock_run_exports):
         """Test export_interactive fallback with All selection."""
-        mock_prompt.ask.return_value = "4"
+        mock_prompt.ask.return_value = "5"
 
         result = MagicMock()
         out_dir = Path("/tmp")
@@ -329,7 +329,7 @@ class TestExportFunctions:
         with patch.dict("sys.modules", {"readchar": None}):
             export_interactive(result, out_dir)
 
-            mock_run_exports.assert_called_once_with(result, ["json", "html", "csv"], out_dir)
+            mock_run_exports.assert_called_once_with(result, ["json", "html", "csv", "sarif"], out_dir)
 
 
 class TestCompareMode:

--- a/tests/unit/test_sarif_reporter.py
+++ b/tests/unit/test_sarif_reporter.py
@@ -1,0 +1,100 @@
+import json
+from datetime import UTC, datetime
+from io import StringIO
+
+import pytest
+
+from slowql.core.models import (
+    AnalysisResult,
+    Dimension,
+    Issue,
+    Location,
+    Severity,
+    Statistics,
+)
+from slowql.reporters.sarif_reporter import SARIFReporter
+
+def _create_mock_result() -> AnalysisResult:
+    issues = [
+        Issue(
+            rule_id="SEC-INJ-001",
+            message="Critical SQL injection found",
+            severity=Severity.CRITICAL,
+            dimension=Dimension.SECURITY,
+            location=Location(line=10, column=5, end_line=10, end_column=20, file="main.sql"),
+            snippet="SELECT *",
+        ),
+        Issue(
+            rule_id="QUAL-STYLE-002",
+            message="Medium styling issue",
+            severity=Severity.MEDIUM,
+            dimension=Dimension.QUALITY,
+            location=Location(line=15, column=2, file="main.sql"),
+            snippet="SELECT a",
+        ),
+        Issue(
+            rule_id="PERF-INDEX-003",
+            message="Low performance note",
+            severity=Severity.LOW,
+            dimension=Dimension.PERFORMANCE,
+            location=Location(line=20, column=0),
+            snippet="SELECT b",
+        )
+    ]
+    result = AnalysisResult(
+        issues=issues,
+        statistics=Statistics(),
+        timestamp=datetime.now(UTC),
+        version="2.1.0",
+    )
+    return result
+
+def test_sarif_reporter_structure_and_mapping() -> None:
+    result = _create_mock_result()
+    output = StringIO()
+    reporter = SARIFReporter(output_file=output)
+    reporter.report(result)
+    
+    json_output = output.getvalue()
+    data = json.loads(json_output)
+    
+    assert data["version"] == "2.1.0"
+    assert data["$schema"] == "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
+    assert len(data["runs"]) == 1
+    
+    run = data["runs"][0]
+    assert run["tool"]["driver"]["name"] == "SlowQL"
+    assert run["tool"]["driver"]["version"] == "2.1.0"
+    
+    # Check rules metadata collection
+    rules = run["tool"]["driver"]["rules"]
+    assert len(rules) == 3
+    rule_ids = {r["id"] for r in rules}
+    assert rule_ids == {"SEC-INJ-001", "QUAL-STYLE-002", "PERF-INDEX-003"}
+    
+    # Check issue mappings
+    results = run["results"]
+    assert len(results) == 3
+    
+    # Critical mapped to error
+    assert results[0]["ruleId"] == "SEC-INJ-001"
+    assert results[0]["level"] == "error"
+    loc1 = results[0]["locations"][0]["physicalLocation"]
+    assert loc1["artifactLocation"]["uri"] == "main.sql"
+    assert loc1["region"]["startLine"] == 10
+    assert loc1["region"]["endLine"] == 10
+    assert loc1["region"]["startColumn"] == 5
+    assert loc1["region"]["endColumn"] == 20
+    
+    # Medium mapped to warning
+    assert results[1]["ruleId"] == "QUAL-STYLE-002"
+    assert results[1]["level"] == "warning"
+    loc2 = results[1]["locations"][0]["physicalLocation"]
+    assert "endLine" not in loc2["region"]
+    assert loc2["region"]["startColumn"] == 2
+    
+    # Low mapped to note
+    assert results[2]["ruleId"] == "PERF-INDEX-003"
+    assert results[2]["level"] == "note"
+    loc3 = results[2]["locations"][0]["physicalLocation"]
+    assert loc3["artifactLocation"]["uri"] == "unknown"


### PR DESCRIPTION
## Summary

This PR adds SARIF output support to SlowQL.

## What changed

- added SARIF reporter support
- exposed `sarif` through CLI/reporting flows
- added/exported SARIF in report paths
- ensured `--format sarif` produces pure SARIF JSON on stdout
- updated tests for the new output mode

## Validation

- `ruff` passes
- `mypy` passes
- full suite passes (`925 passed`)
- manual SARIF contract check confirmed:
  - valid JSON
  - SARIF version `2.1.0`
  - one `runs` entry