### PR TITLE
test: harden LSP diagnostics foundation

### DIFF
--- a/src/slowql/lsp/server.py
+++ b/src/slowql/lsp/server.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from slowql.core.models import Issue, Severity
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from lsprotocol.types import (
+        DidChangeTextDocumentParams,
+        DidOpenTextDocumentParams,
+        DidSaveTextDocumentParams,
+    )
 
 try:
     from lsprotocol.types import (
@@ -14,9 +21,6 @@ try:
         TEXT_DOCUMENT_DID_SAVE,
         Diagnostic,
         DiagnosticSeverity,
-        DidChangeTextDocumentParams,
-        DidOpenTextDocumentParams,
-        DidSaveTextDocumentParams,
         Position,
         PublishDiagnosticsParams,
         Range,
@@ -65,6 +69,15 @@ except ImportError:
             self.severity = severity
             self.source = source
             self.code = code
+
+    class PublishDiagnosticsParams:  # type: ignore[no-redef]
+        def __init__(self, uri: str, diagnostics: list[Diagnostic]) -> None:
+            self.uri = uri
+            self.diagnostics = diagnostics
+
+    TEXT_DOCUMENT_DID_OPEN = "textDocument/didOpen"
+    TEXT_DOCUMENT_DID_CHANGE = "textDocument/didChange"
+    TEXT_DOCUMENT_DID_SAVE = "textDocument/didSave"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_lsp_foundation.py
+++ b/tests/unit/test_lsp_foundation.py
@@ -1,29 +1,31 @@
 from __future__ import annotations
 
-import sys
-from unittest.mock import patch
+import logging
 
 import pytest
 
+import slowql.core.engine as engine_module
 from slowql.core.models import Issue, Location, Severity
-from slowql.lsp.server import HAS_PYGLS, issue_to_diagnostic, map_severity
+from slowql.lsp import server as lsp_server
 
-if HAS_PYGLS:
+if lsp_server.HAS_PYGLS:
     from lsprotocol.types import DiagnosticSeverity
 else:
+
     class DiagnosticSeverity:
         Error = 1
         Warning = 2
         Information = 3
         Hint = 4
 
+
 def test_severity_mapping():
     """Test mapping SlowQL Severity to LSP DiagnosticSeverity."""
-    assert map_severity(Severity.CRITICAL) == DiagnosticSeverity.Error
-    assert map_severity(Severity.HIGH) == DiagnosticSeverity.Error
-    assert map_severity(Severity.MEDIUM) == DiagnosticSeverity.Warning
-    assert map_severity(Severity.LOW) == DiagnosticSeverity.Information
-    assert map_severity(Severity.INFO) == DiagnosticSeverity.Hint
+    assert lsp_server.map_severity(Severity.CRITICAL) == DiagnosticSeverity.Error
+    assert lsp_server.map_severity(Severity.HIGH) == DiagnosticSeverity.Error
+    assert lsp_server.map_severity(Severity.MEDIUM) == DiagnosticSeverity.Warning
+    assert lsp_server.map_severity(Severity.LOW) == DiagnosticSeverity.Information
+    assert lsp_server.map_severity(Severity.INFO) == DiagnosticSeverity.Hint
 
 
 def test_issue_to_diagnostic():
@@ -42,7 +44,7 @@ def test_issue_to_diagnostic():
         ),
     )
 
-    diagnostic = issue_to_diagnostic(issue)
+    diagnostic = lsp_server.issue_to_diagnostic(issue)
 
     assert diagnostic.message == "Test issue"
     assert diagnostic.code == "TST-001"
@@ -57,9 +59,286 @@ def test_issue_to_diagnostic():
     assert diagnostic.range.end.character == 5
 
 
-def test_graceful_failure_without_pygls():
-    """Test that SlowQLLanguageServer fails gracefully when pygls is absent."""
-    with patch.dict(sys.modules, {"pygls": None, "lsprotocol": None}), patch("slowql.lsp.server.HAS_PYGLS", False):
-        from slowql.lsp.server import SlowQLLanguageServer
-        with pytest.raises(ImportError, match="pygls library is required"):
-                SlowQLLanguageServer()
+def test_language_server_fallback_raises_import_error(monkeypatch):
+    """Test that SlowQLLanguageServer raises ImportError when HAS_PYGLS is False."""
+    monkeypatch.setattr(lsp_server, "HAS_PYGLS", False)
+
+    with pytest.raises(ImportError, match="pygls library is required"):
+        lsp_server.SlowQLLanguageServer()
+
+
+def test_validate_document_publishes_diagnostics(monkeypatch):
+    """Test _validate_document publishes diagnostics correctly."""
+
+    class FakeServer:
+        def __init__(self):
+            self.published = None
+            self.logger = logging.getLogger("fake_server")
+
+        def text_document_publish_diagnostics(self, params):
+            self.published = params
+
+    fake_server = FakeServer()
+    uri = "file:///test.sql"
+    source = "SELECT * FROM users"
+
+    class FakeResult:
+        def __init__(self):
+            self.issues = [
+                Issue(
+                    rule_id="RL-001",
+                    message="Test issue",
+                    severity=Severity.HIGH,
+                    dimension="quality",
+                    snippet="SELECT",
+                    location=Location(line=1, column=1),
+                )
+            ]
+
+    monkeypatch.setattr(engine_module.SlowQL, "analyze", lambda *_args, **_kwargs: FakeResult())
+
+    lsp_server._validate_document(fake_server, uri, source)  # type: ignore[arg-type]
+
+    assert fake_server.published is not None
+    assert fake_server.published.uri == uri
+    assert len(fake_server.published.diagnostics) == 1
+    assert fake_server.published.diagnostics[0].message == "Test issue"
+
+
+def test_validate_document_on_engine_failure_publishes_empty_diagnostics(monkeypatch):
+    """Test _validate_document handles engine failure by publishing empty diagnostics."""
+
+    class FakeServer:
+        def __init__(self):
+            self.published = None
+            self.logger = logging.getLogger("fake_server")
+
+        def text_document_publish_diagnostics(self, params):
+            self.published = params
+
+    fake_server = FakeServer()
+
+    def raise_err(*_args, **_kwargs):
+        raise RuntimeError("Engine crash")
+
+    monkeypatch.setattr(engine_module.SlowQL, "analyze", raise_err)
+
+    lsp_server._validate_document(fake_server, "file:///test.sql", "SELECT 1")  # type: ignore[arg-type]
+
+    assert fake_server.published is not None
+    assert len(fake_server.published.diagnostics) == 0
+
+
+def test_create_server_registers_handlers(monkeypatch):
+    """Test create_server registers required feature handlers."""
+    features = {}
+
+    class FakeServer:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def feature(self, feature_name):
+            def decorator(f):
+                features[feature_name] = f
+                return f
+
+            return decorator
+
+    monkeypatch.setattr(lsp_server, "SlowQLLanguageServer", FakeServer)
+
+    lsp_server.create_server()
+
+    assert lsp_server.TEXT_DOCUMENT_DID_OPEN in features
+    assert lsp_server.TEXT_DOCUMENT_DID_CHANGE in features
+    assert lsp_server.TEXT_DOCUMENT_DID_SAVE in features
+
+
+def test_create_server_did_open_handler(monkeypatch):
+    """Test the did_open handler calls _validate_document."""
+    captured_handlers = {}
+
+    class MockServer:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def feature(self, name):
+            def wrapper(f):
+                captured_handlers[name] = f
+                return f
+
+            return wrapper
+
+    monkeypatch.setattr(lsp_server, "SlowQLLanguageServer", MockServer)
+
+    validated = []
+
+    def fake_validate(_ls, uri, text):
+        validated.append((uri, text))
+
+    monkeypatch.setattr(lsp_server, "_validate_document", fake_validate)
+
+    srv = lsp_server.create_server()
+
+    class FakeDoc:
+        def __init__(self):
+            self.uri = "file:///test.sql"
+            self.text = "SELECT 1"
+
+    class FakeParams:
+        def __init__(self):
+            self.text_document = FakeDoc()
+
+    handler = captured_handlers[lsp_server.TEXT_DOCUMENT_DID_OPEN]
+
+    params = FakeParams()
+    handler(srv, params)
+
+    assert len(validated) == 1
+    assert validated[0] == ("file:///test.sql", "SELECT 1")
+
+
+def test_create_server_did_change_handler_uses_latest_change(monkeypatch):
+    """Test did_change handler uses the last change in the list."""
+    validated = []
+
+    def fake_validate(_ls, uri, text):
+        validated.append((uri, text))
+
+    monkeypatch.setattr(lsp_server, "_validate_document", fake_validate)
+
+    captured_handlers = {}
+
+    class MockServer:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def feature(self, name):
+            def wrapper(f):
+                captured_handlers[name] = f
+                return f
+
+            return wrapper
+
+    monkeypatch.setattr(lsp_server, "SlowQLLanguageServer", MockServer)
+
+    srv = lsp_server.create_server()
+    handler = captured_handlers[lsp_server.TEXT_DOCUMENT_DID_CHANGE]
+
+    class FakeDoc:
+        def __init__(self):
+            self.uri = "file:///test.sql"
+
+    class FakeChange:
+        def __init__(self, text):
+            self.text = text
+
+    class FakeParams:
+        def __init__(self):
+            self.text_document = FakeDoc()
+            self.content_changes = [
+                FakeChange("old"),
+                FakeChange("new"),
+            ]
+
+    handler(srv, FakeParams())
+
+    assert len(validated) == 1
+    assert validated[0][1] == "new"
+
+
+def test_create_server_did_save_handler_with_text(monkeypatch):
+    """Test did_save handler calls validate if text is present."""
+    validated = []
+
+    def fake_validate(_ls, uri, text):
+        validated.append((uri, text))
+
+    monkeypatch.setattr(lsp_server, "_validate_document", fake_validate)
+
+    captured_handlers = {}
+
+    class MockServer:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def feature(self, name):
+            def wrapper(f):
+                captured_handlers[name] = f
+                return f
+
+            return wrapper
+
+    monkeypatch.setattr(lsp_server, "SlowQLLanguageServer", MockServer)
+
+    srv = lsp_server.create_server()
+    handler = captured_handlers[lsp_server.TEXT_DOCUMENT_DID_SAVE]
+
+    class FakeDoc:
+        def __init__(self):
+            self.uri = "file:///test.sql"
+
+    class FakeParams:
+        def __init__(self):
+            self.text_document = FakeDoc()
+            self.text = "saved text"
+
+    handler(srv, FakeParams())
+
+    assert len(validated) == 1
+    assert validated[0][1] == "saved text"
+
+
+def test_create_server_did_save_handler_without_text(monkeypatch):
+    """Test did_save handler does not call validate if text is None."""
+    validated = []
+
+    def fake_validate(_ls, uri, text):
+        validated.append((uri, text))
+
+    monkeypatch.setattr(lsp_server, "_validate_document", fake_validate)
+
+    captured_handlers = {}
+
+    class MockServer:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def feature(self, name):
+            def wrapper(f):
+                captured_handlers[name] = f
+                return f
+
+            return wrapper
+
+    monkeypatch.setattr(lsp_server, "SlowQLLanguageServer", MockServer)
+
+    srv = lsp_server.create_server()
+    handler = captured_handlers[lsp_server.TEXT_DOCUMENT_DID_SAVE]
+
+    class FakeDoc:
+        def __init__(self):
+            self.uri = "file:///test.sql"
+
+    class FakeParams:
+        def __init__(self):
+            self.text_document = FakeDoc()
+            self.text = None
+
+    handler(srv, FakeParams())
+
+    assert len(validated) == 0
+
+
+def test_main_starts_io(monkeypatch):
+    """Test main() correctly starts the server."""
+    started = False
+
+    class FakeServer:
+        def start_io(self):
+            nonlocal started
+            started = True
+
+    monkeypatch.setattr(lsp_server, "create_server", lambda: FakeServer())
+
+    lsp_server.main()
+    assert started is True


### PR DESCRIPTION
## Summary

This PR hardens SlowQL's LSP diagnostics foundation.

## Improvements
- increased `slowql.lsp.server` coverage significantly
- added tests for:
  - document validation success/failure
  - diagnostics publishing
  - server factory handler registration
  - didOpen / didChange / didSave behavior
  - main() startup path
- cleaned LSP typing/import structure to satisfy Ruff and mypy
- preserved existing runtime behavior

## Validation
- `ruff check src tests`
- `mypy src`
- `pytest`
- total coverage: 94.77%

## Why
This strengthens the foundation for VS Code / LSP editor integrations and improves confidence in real-time SQL diagnostics.