### PR TITLE
chore: polish release and documentation surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,29 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [1.5.0] - 2026-03-13
+
+### Added
+- Conservative autofix foundation
+- `--diff` preview mode
+- `--fix` safe apply mode with backup support
+- `--fail-on` severity threshold support
+- `github-actions` output format
+- `--fix-report` JSON output
+- Source-anchored parser support
+- Remediation mode classification
+- Safe autofixes for:
+  - `QUAL-NULL-001`
+  - `QUAL-STYLE-002`
+
+### Changed
+- Non-interactive session export now requires explicit `--export-session`
+- Multi-file CLI input improved for automation/pre-commit style use
+
+---
+
 ## [1.3.0] - 2025-12-19
+
 ### Added
 - Enhanced SQL analyzer with improved security and performance detection
 - New compliance checks for GDPR, HIPAA, and PCI-DSS standards
@@ -26,6 +48,7 @@ All notable changes to this project will be documented here.
 ---
 
 ## [1.0.3] - 2025-12-03
+
 ### Added
 - Initial release of SlowQL
 - Critical and High severity detectors
@@ -33,23 +56,3 @@ All notable changes to this project will be documented here.
 
 ### Fixed
 - MkDocs strict build errors
-
-
-## 1.5.0
-
-### Added
-- Conservative autofix foundation
-- `--diff` preview mode
-- `--fix` safe apply mode with backup support
-- `--fail-on` severity threshold support
-- `github-actions` output format
-- `--fix-report` JSON output
-- Source-anchored parser support
-- Remediation mode classification
-- Safe autofixes for:
-  - `QUAL-NULL-001`
-  - `QUAL-STYLE-002`
-
-### Changed
-- Non-interactive session export now requires explicit `--export-session`
-- Multi-file CLI input improved for automation/pre-commit style use

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,8 +5,6 @@ plugins:
   - search
 nav:
   - Home: index.md
-nav:
-  - Home: index.md
   - Getting Started:
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quick-start.md

--- a/src/slowql/__main__.py
+++ b/src/slowql/__main__.py
@@ -1,9 +1,6 @@
-# slowql/src/slowql/__main__.py
-"""
-Entry point for python -m slowql
-"""
+import sys
 
 from slowql.cli.app import main
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This PR polishes SlowQL release, docs, and entrypoint surfaces.

## Changes

- fix `python -m slowql` to return the CLI exit code correctly
- clean up `mkdocs.yml` structure
- normalize `CHANGELOG.md` version formatting
- keep release/documentation surface more consistent and reliable

## Validation
- `ruff check src tests` 
- `mypy src` 
- `pytest` 
- total coverage: 94.75%

## Why
This improves release hygiene, documentation reliability, and overall polish for users and contributors.
