### PR TITLE
feat: add suggest_fix() to ReadUncommittedHintRule (PERF-LOCK-002)

### DIFF
--- a/src/slowql/rules/performance/locking.py
+++ b/src/slowql/rules/performance/locking.py
@@ -1,12 +1,20 @@
 """
 Performance Locking rules.
 """
-
 from __future__ import annotations
 
+import re
 from typing import Any
 
-from slowql.core.models import Category, Dimension, Fix, Issue, Query, Severity
+from slowql.core.models import (
+    Category,
+    Dimension,
+    Fix,
+    FixConfidence,
+    Issue,
+    Query,
+    Severity,
+)
 from slowql.rules.base import ASTRule, PatternRule
 
 __all__ = [
@@ -59,6 +67,30 @@ class ReadUncommittedHintRule(PatternRule):
     fix_guidance = (
         "Use READ COMMITTED SNAPSHOT ISOLATION (RCSI) for non-blocking reads without dirty reads."
     )
+
+    def suggest_fix(self, query: Query) -> Fix | None:
+        """
+        Suggests a fix to remove the WITH (NOLOCK) or WITH (READUNCOMMITTED) hint.
+        Only fires on the WITH (...) hint form to avoid changing transaction semantics.
+        """
+        try:
+            match = re.search(
+                r"\bWITH\s*\(\s*(NOLOCK|READUNCOMMITTED)\s*\)",
+                query.raw,
+                re.IGNORECASE,
+            )
+            if not match:
+                return None
+            return Fix(
+                description="Remove NOLOCK/READUNCOMMITTED hint to prevent dirty reads",
+                original=match.group(0),
+                replacement="",
+                confidence=FixConfidence.SAFE,
+                rule_id=self.id,
+                is_safe=True,
+            )
+        except Exception:
+            return None
 
 
 class LongTransactionPatternRule(PatternRule):

--- a/tests/unit/test_autofix_readuncommitted.py
+++ b/tests/unit/test_autofix_readuncommitted.py
@@ -1,0 +1,44 @@
+from slowql.core.models import FixConfidence
+from slowql.parser.universal import UniversalParser
+from slowql.rules.performance.locking import ReadUncommittedHintRule
+
+parser = UniversalParser()
+
+def _parse(sql):
+    return parser.parse(sql)[0]
+
+def test_fires_on_nolock():
+    q = _parse("SELECT * FROM t WITH (NOLOCK)")
+    fix = ReadUncommittedHintRule().suggest_fix(q)
+    assert fix is not None
+    assert fix.replacement == ""
+    assert "WITH (NOLOCK)" in fix.original or "with (nolock)" in fix.original.lower()
+    assert fix.is_safe is True
+    assert fix.confidence == FixConfidence.SAFE
+
+def test_fires_on_readuncommitted_hint():
+    q = _parse("SELECT * FROM t WITH (READUNCOMMITTED)")
+    fix = ReadUncommittedHintRule().suggest_fix(q)
+    assert fix is not None
+    assert fix.replacement == ""
+    assert fix.is_safe is True
+    assert fix.confidence == FixConfidence.SAFE
+
+def test_result_has_hint_removed():
+    sql = "SELECT * FROM t WITH (NOLOCK)"
+    q = _parse(sql)
+    fix = ReadUncommittedHintRule().suggest_fix(q)
+    assert fix is not None
+    result = sql.replace(fix.original, fix.replacement, 1)
+    assert "NOLOCK" not in result.upper()
+    assert "SELECT * FROM t" in result
+
+def test_does_not_fire_on_read_uncommitted_bare():
+    q = _parse("SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED")
+    fix = ReadUncommittedHintRule().suggest_fix(q)
+    assert fix is None
+
+def test_does_not_fire_on_clean_query():
+    q = _parse("SELECT * FROM t WHERE id = 1")
+    fix = ReadUncommittedHintRule().suggest_fix(q)
+    assert fix is None


### PR DESCRIPTION
## Safe autofix expansion

### What
Adds `suggest_fix()` to `ReadUncommittedHintRule` (PERF-LOCK-002).

### The fix
Removes `WITH (NOLOCK)` and `WITH (READUNCOMMITTED)` hints. Removing these makes reads consistent — strictly safer after fix than before.

### Safety
- Only fires on the hint form `WITH (NOLOCK)` / `WITH (READUNCOMMITTED)`
- Returns None for `SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED`: removing that would change transaction semantics
- FixConfidence.SAFE, is_safe=True
- 5 targeted tests cover fire, guard, and result correctness

### What was evaluated and rejected
- UnionWithoutAllRule: UNION→UNION ALL changes semantics if duplicates matter
- OrderByInSubqueryRule: regex can't safely detect LIMIT/TOP boundary
- ImplicitJoinRule: requires schema to determine correct join predicate

### Verification
- 1104 tests passing (1099 existing + 5 new)
- ruff clean, mypy clean